### PR TITLE
Add type hints to improve performance

### DIFF
--- a/src/clj_templates/lex.clj
+++ b/src/clj_templates/lex.clj
@@ -2,12 +2,12 @@
   (:require [clj-templates.util :as util])
   (:import [java.util Arrays]))
 
-(defn create [a]
+(defn create [^ints a]
   {:current (atom 0)
    :end (alength a)
    :arr a})
 
-(defn from-string [s]
+(defn from-string [^ints s]
   (create (util/string->codepoints s)))
 
 (defn create-child [lex start end]
@@ -15,7 +15,7 @@
    :end end
    :arr (:arr lex)})
 
-(defn codepoints-between [{:keys [arr] :as lex} from to]
+(defn codepoints-between [{:keys [^ints arr] :as lex} ^long from ^long to]
   (Arrays/copyOfRange arr from to))
 
 (defn codepoints-from [{:keys [end] :as lex} position]
@@ -33,10 +33,10 @@
   (>= @current end))
 
 (defn peek
-  ([{:keys [arr current] :as lex}]
+  ([{:keys [^ints arr current] :as lex}]
    (if (not (end? lex))
      (aget arr @current)))
-  ([{:keys [arr current] :as lex} offset]
+  ([{:keys [^ints arr current] :as lex} offset]
    (let [p (+ offset @current)]
      (if (<= p (alength arr))
        (aget arr p)))))

--- a/src/clj_templates/util.clj
+++ b/src/clj_templates/util.clj
@@ -10,7 +10,7 @@
   Integer
   (to-codepoint [i] i))
 
-(defn codepoint->string [cp]
+(defn ^String codepoint->string [cp]
   (String. (int-array 1 [cp]) 0 1))
 
 (defn codepoint->utf8
@@ -18,13 +18,13 @@
   [cp]
   (.getBytes (codepoint->string cp)))
 
-(defn string->codepoints [s]
+(defn string->codepoints [^String s]
   (.. s (codePoints) (toArray)))
 
 (defn codepoints->string
   "Converts a sequences of codepoints to a string"
   [codepoints]
-  (let [arr (int-array codepoints)        
+  (let [arr (int-array codepoints)
         offset 0
         count (alength arr)]
     (String. arr offset count)))


### PR DESCRIPTION
We should probably add criterium for proper performance testing but adding type hints improves performance by at least an order of magnitude:

```clojure
;; Without hints
(time (dotimes [n 10000] (expand "{?foo}" {:foo 10})))
"Elapsed time: 4528.385679 msecs"
```

```clojure
;; With hints
(time (dotimes [n 10000] (expand "{?foo}" {:foo 10})))
"Elapsed time: 230.755874 msecs"```